### PR TITLE
Conform shield sizes and style to shields.io

### DIFF
--- a/badges/0.1.0/abandoned-flat.svg
+++ b/badges/0.1.0/abandoned-flat.svg
@@ -1,0 +1,23 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="148" height="20">
+  <linearGradient id="smooth" x2="0" y2="100%">
+    <stop offset="0" stop-color="#bbb" stop-opacity=".1"/>
+    <stop offset="1" stop-opacity=".1"/>
+  </linearGradient>
+
+  <mask id="round">
+    <rect width="148" height="20" rx="3" fill="#fff"/>
+  </mask>
+
+  <g mask="url(#round)">
+    <rect width="148" height="20" fill="#555"/>
+    <rect x="74" width="74" height="20" fill="black"/>
+    <rect width="148" height="20" fill="url(#smooth)"/>
+  </g>
+
+  <g fill="#fff" text-anchor="middle" font-family="DejaVu Sans,Verdana,Geneva,sans-serif" font-size="11">
+    <text x="38" y="15" fill="#010101" fill-opacity=".3">repo status</text>
+    <text x="38" y="14">repo status</text>
+    <text x="110" y="15" fill="#010101" fill-opacity=".3">Abandoned</text>
+    <text x="110" y="14">Abandoned</text>
+  </g>
+</svg>

--- a/badges/0.1.0/abandoned.svg
+++ b/badges/0.1.0/abandoned.svg
@@ -1,1 +1,25 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="148" height="18"><linearGradient id="a" x2="0" y2="100%"><stop offset="0" stop-color="#fff" stop-opacity=".7"/><stop offset=".1" stop-color="#aaa" stop-opacity=".1"/><stop offset=".9" stop-opacity=".3"/><stop offset="1" stop-opacity=".5"/></linearGradient><rect rx="4" width="148" height="18" fill="#555"/><rect rx="4" x="74" width="74" height="18"/><path d="M74 0h4v18h-4z"/><rect rx="4" width="148" height="18" fill="url(#a)"/><g fill="#fff" text-anchor="middle" font-family="DejaVu Sans,Verdana,Geneva,sans-serif" font-size="11"><text x="38" y="14" fill="#010101" fill-opacity=".3">repo status</text><text x="38" y="13">repo status</text><text x="110" y="14" fill="#010101" fill-opacity=".3">Abandoned</text><text x="110" y="13">Abandoned</text></g></svg>
+<svg xmlns="http://www.w3.org/2000/svg" width="148" height="20">
+  <linearGradient id="smooth" x2="0" y2="100%">
+    <stop offset="0"  stop-color="#fff" stop-opacity=".7"/>
+    <stop offset=".1" stop-color="#aaa" stop-opacity=".1"/>
+    <stop offset=".9" stop-color="#000" stop-opacity=".3"/>
+    <stop offset="1"  stop-color="#000" stop-opacity=".5"/>
+  </linearGradient>
+
+  <mask id="round">
+    <rect width="148" height="20" rx="3" fill="#fff"/>
+  </mask>
+
+  <g mask="url(#round)">
+    <rect width="148" height="20" fill="#555"/>
+    <rect x="74" width="74" height="20" fill="black"/>
+    <rect width="148" height="20" fill="url(#smooth)"/>
+  </g>
+
+  <g fill="#fff" text-anchor="middle" font-family="DejaVu Sans,Verdana,Geneva,sans-serif" font-size="11">
+    <text x="38" y="15" fill="#010101" fill-opacity=".3">repo status</text>
+    <text x="38" y="14">repo status</text>
+    <text x="110" y="15" fill="#010101" fill-opacity=".3">Abandoned</text>
+    <text x="110" y="14">Abandoned</text>
+  </g>
+</svg>

--- a/badges/0.1.0/active-flat.svg
+++ b/badges/0.1.0/active-flat.svg
@@ -1,0 +1,23 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="119" height="20">
+  <linearGradient id="smooth" x2="0" y2="100%">
+    <stop offset="0" stop-color="#bbb" stop-opacity=".1"/>
+    <stop offset="1" stop-opacity=".1"/>
+  </linearGradient>
+
+  <mask id="round">
+    <rect width="119" height="20" rx="3" fill="#fff"/>
+  </mask>
+
+  <g mask="url(#round)">
+    <rect width="119" height="20" fill="#555"/>
+    <rect x="74" width="45" height="20" fill="#4c1"/>
+    <rect width="119" height="20" fill="url(#smooth)"/>
+  </g>
+
+  <g fill="#fff" text-anchor="middle" font-family="DejaVu Sans,Verdana,Geneva,sans-serif" font-size="11">
+    <text x="38" y="15" fill="#010101" fill-opacity=".3">repo status</text>
+    <text x="38" y="14">repo status</text>
+    <text x="95.5" y="15" fill="#010101" fill-opacity=".3">Active</text>
+    <text x="95.5" y="14">Active</text>
+  </g>
+</svg>

--- a/badges/0.1.0/active.svg
+++ b/badges/0.1.0/active.svg
@@ -1,1 +1,25 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="119" height="18"><linearGradient id="a" x2="0" y2="100%"><stop offset="0" stop-color="#fff" stop-opacity=".7"/><stop offset=".1" stop-color="#aaa" stop-opacity=".1"/><stop offset=".9" stop-opacity=".3"/><stop offset="1" stop-opacity=".5"/></linearGradient><rect rx="4" width="119" height="18" fill="#555"/><rect rx="4" x="74" width="45" height="18" fill="#4c1"/><path fill="#4c1" d="M74 0h4v18h-4z"/><rect rx="4" width="119" height="18" fill="url(#a)"/><g fill="#fff" text-anchor="middle" font-family="DejaVu Sans,Verdana,Geneva,sans-serif" font-size="11"><text x="38" y="14" fill="#010101" fill-opacity=".3">repo status</text><text x="38" y="13">repo status</text><text x="95.5" y="14" fill="#010101" fill-opacity=".3">Active</text><text x="95.5" y="13">Active</text></g></svg>
+<svg xmlns="http://www.w3.org/2000/svg" width="119" height="20">
+  <linearGradient id="smooth" x2="0" y2="100%">
+    <stop offset="0"  stop-color="#fff" stop-opacity=".7"/>
+    <stop offset=".1" stop-color="#aaa" stop-opacity=".1"/>
+    <stop offset=".9" stop-color="#000" stop-opacity=".3"/>
+    <stop offset="1"  stop-color="#000" stop-opacity=".5"/>
+  </linearGradient>
+
+  <mask id="round">
+    <rect width="119" height="20" rx="3" fill="#fff"/>
+  </mask>
+
+  <g mask="url(#round)">
+    <rect width="119" height="20" fill="#555"/>
+    <rect x="74" width="45" height="20" fill="#4c1"/>
+    <rect width="119" height="20" fill="url(#smooth)"/>
+  </g>
+
+  <g fill="#fff" text-anchor="middle" font-family="DejaVu Sans,Verdana,Geneva,sans-serif" font-size="11">
+    <text x="38" y="15" fill="#010101" fill-opacity=".3">repo status</text>
+    <text x="38" y="14">repo status</text>
+    <text x="95.5" y="15" fill="#010101" fill-opacity=".3">Active</text>
+    <text x="95.5" y="14">Active</text>
+  </g>
+</svg>

--- a/badges/0.1.0/concept-flat.svg
+++ b/badges/0.1.0/concept-flat.svg
@@ -1,0 +1,23 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="131" height="20">
+  <linearGradient id="smooth" x2="0" y2="100%">
+    <stop offset="0" stop-color="#bbb" stop-opacity=".1"/>
+    <stop offset="1" stop-opacity=".1"/>
+  </linearGradient>
+
+  <mask id="round">
+    <rect width="131" height="20" rx="3" fill="#fff"/>
+  </mask>
+
+  <g mask="url(#round)">
+    <rect width="131" height="20" fill="#555"/>
+    <rect x="74" width="57" height="20" fill="#fff"/>
+    <rect width="131" height="20" fill="url(#smooth)"/>
+  </g>
+
+  <g fill="#fff" text-anchor="middle" font-family="DejaVu Sans,Verdana,Geneva,sans-serif" font-size="11">
+    <text x="38" y="15" fill="#010101" fill-opacity=".3">repo status</text>
+    <text x="38" y="14">repo status</text>
+    <text x="101.5" y="15" fill="#010101" fill-opacity=".3">Concept</text>
+    <text x="101.5" y="14">Concept</text>
+  </g>
+</svg>

--- a/badges/0.1.0/concept.svg
+++ b/badges/0.1.0/concept.svg
@@ -1,1 +1,25 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="131" height="18"><linearGradient id="a" x2="0" y2="100%"><stop offset="0" stop-color="#fff" stop-opacity=".7"/><stop offset=".1" stop-color="#aaa" stop-opacity=".1"/><stop offset=".9" stop-opacity=".3"/><stop offset="1" stop-opacity=".5"/></linearGradient><rect rx="4" width="131" height="18" fill="#555"/><rect rx="4" x="74" width="57" height="18" fill="#fff"/><path fill="#fff" d="M74 0h4v18h-4z"/><rect rx="4" width="131" height="18" fill="url(#a)"/><g fill="#fff" text-anchor="middle" font-family="DejaVu Sans,Verdana,Geneva,sans-serif" font-size="11"><text x="38" y="14" fill="#010101" fill-opacity=".3">repo status</text><text x="38" y="13">repo status</text><text x="101.5" y="14" fill="#010101" fill-opacity=".3">Concept</text><text x="101.5" y="13">Concept</text></g></svg>
+<svg xmlns="http://www.w3.org/2000/svg" width="131" height="20">
+  <linearGradient id="smooth" x2="0" y2="100%">
+    <stop offset="0"  stop-color="#fff" stop-opacity=".7"/>
+    <stop offset=".1" stop-color="#aaa" stop-opacity=".1"/>
+    <stop offset=".9" stop-color="#000" stop-opacity=".3"/>
+    <stop offset="1"  stop-color="#000" stop-opacity=".5"/>
+  </linearGradient>
+
+  <mask id="round">
+    <rect width="131" height="20" rx="3" fill="#fff"/>
+  </mask>
+
+  <g mask="url(#round)">
+    <rect width="131" height="20" fill="#555"/>
+    <rect x="74" width="57" height="20" fill="#fff"/>
+    <rect width="131" height="20" fill="url(#smooth)"/>
+  </g>
+
+  <g fill="#fff" text-anchor="middle" font-family="DejaVu Sans,Verdana,Geneva,sans-serif" font-size="11">
+    <text x="38" y="15" fill="#010101" fill-opacity=".3">repo status</text>
+    <text x="38" y="14">repo status</text>
+    <text x="101.5" y="15" fill="#010101" fill-opacity=".3">Concept</text>
+    <text x="101.5" y="14">Concept</text>
+  </g>
+</svg>

--- a/badges/0.1.0/inactive-flat.svg
+++ b/badges/0.1.0/inactive-flat.svg
@@ -1,0 +1,23 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="131" height="20">
+  <linearGradient id="smooth" x2="0" y2="100%">
+    <stop offset="0" stop-color="#bbb" stop-opacity=".1"/>
+    <stop offset="1" stop-opacity=".1"/>
+  </linearGradient>
+
+  <mask id="round">
+    <rect width="131" height="20" rx="3" fill="#fff"/>
+  </mask>
+
+  <g mask="url(#round)">
+    <rect width="131" height="20" fill="#555"/>
+    <rect x="74" width="56" height="20" fill="#a4a61d"/>
+    <rect width="131" height="20" fill="url(#smooth)"/>
+  </g>
+
+  <g fill="#fff" text-anchor="middle" font-family="DejaVu Sans,Verdana,Geneva,sans-serif" font-size="11">
+    <text x="38" y="15" fill="#010101" fill-opacity=".3">repo status</text>
+    <text x="38" y="14">repo status</text>
+    <text x="101" y="15" fill="#010101" fill-opacity=".3">Inactive</text>
+    <text x="101" y="14">Inactive</text>
+  </g>
+</svg>

--- a/badges/0.1.0/inactive.svg
+++ b/badges/0.1.0/inactive.svg
@@ -1,1 +1,25 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="130" height="18"><linearGradient id="a" x2="0" y2="100%"><stop offset="0" stop-color="#fff" stop-opacity=".7"/><stop offset=".1" stop-color="#aaa" stop-opacity=".1"/><stop offset=".9" stop-opacity=".3"/><stop offset="1" stop-opacity=".5"/></linearGradient><rect rx="4" width="130" height="18" fill="#555"/><rect rx="4" x="74" width="56" height="18" fill="#a4a61d"/><path fill="#a4a61d" d="M74 0h4v18h-4z"/><rect rx="4" width="130" height="18" fill="url(#a)"/><g fill="#fff" text-anchor="middle" font-family="DejaVu Sans,Verdana,Geneva,sans-serif" font-size="11"><text x="38" y="14" fill="#010101" fill-opacity=".3">repo status</text><text x="38" y="13">repo status</text><text x="101" y="14" fill="#010101" fill-opacity=".3">Inactive</text><text x="101" y="13">Inactive</text></g></svg>
+<svg xmlns="http://www.w3.org/2000/svg" width="131" height="20">
+  <linearGradient id="smooth" x2="0" y2="100%">
+    <stop offset="0"  stop-color="#fff" stop-opacity=".7"/>
+    <stop offset=".1" stop-color="#aaa" stop-opacity=".1"/>
+    <stop offset=".9" stop-color="#000" stop-opacity=".3"/>
+    <stop offset="1"  stop-color="#000" stop-opacity=".5"/>
+  </linearGradient>
+
+  <mask id="round">
+    <rect width="131" height="20" rx="3" fill="#fff"/>
+  </mask>
+
+  <g mask="url(#round)">
+    <rect width="131" height="20" fill="#555"/>
+    <rect x="74" width="56" height="20" fill="#a4a61d"/>
+    <rect width="131" height="20" fill="url(#smooth)"/>
+  </g>
+
+  <g fill="#fff" text-anchor="middle" font-family="DejaVu Sans,Verdana,Geneva,sans-serif" font-size="11">
+    <text x="38" y="15" fill="#010101" fill-opacity=".3">repo status</text>
+    <text x="38" y="14">repo status</text>
+    <text x="101" y="15" fill="#010101" fill-opacity=".3">Inactive</text>
+    <text x="101" y="14">Inactive</text>
+  </g>
+</svg>

--- a/badges/0.1.0/suspended-flat.svg
+++ b/badges/0.1.0/suspended-flat.svg
@@ -1,0 +1,23 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="147" height="20">
+  <linearGradient id="smooth" x2="0" y2="100%">
+    <stop offset="0" stop-color="#bbb" stop-opacity=".1"/>
+    <stop offset="1" stop-opacity=".1"/>
+  </linearGradient>
+
+  <mask id="round">
+    <rect width="147" height="20" rx="3" fill="#fff"/>
+  </mask>
+
+  <g mask="url(#round)">
+    <rect width="147" height="20" fill="#555"/>
+    <rect x="74" width="73" height="20" fill="#fe7d37"/>
+    <rect width="147" height="20" fill="url(#smooth)"/>
+  </g>
+
+  <g fill="#fff" text-anchor="middle" font-family="DejaVu Sans,Verdana,Geneva,sans-serif" font-size="11">
+    <text x="38" y="15" fill="#010101" fill-opacity=".3">repo status</text>
+    <text x="38" y="14">repo status</text>
+    <text x="109.5" y="15" fill="#010101" fill-opacity=".3">Suspended</text>
+    <text x="109.5" y="14">Suspended</text>
+  </g>
+</svg>

--- a/badges/0.1.0/suspended.svg
+++ b/badges/0.1.0/suspended.svg
@@ -1,1 +1,25 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="147" height="18"><linearGradient id="a" x2="0" y2="100%"><stop offset="0" stop-color="#fff" stop-opacity=".7"/><stop offset=".1" stop-color="#aaa" stop-opacity=".1"/><stop offset=".9" stop-opacity=".3"/><stop offset="1" stop-opacity=".5"/></linearGradient><rect rx="4" width="147" height="18" fill="#555"/><rect rx="4" x="74" width="73" height="18" fill="#fe7d37"/><path fill="#fe7d37" d="M74 0h4v18h-4z"/><rect rx="4" width="147" height="18" fill="url(#a)"/><g fill="#fff" text-anchor="middle" font-family="DejaVu Sans,Verdana,Geneva,sans-serif" font-size="11"><text x="38" y="14" fill="#010101" fill-opacity=".3">repo status</text><text x="38" y="13">repo status</text><text x="109.5" y="14" fill="#010101" fill-opacity=".3">Suspended</text><text x="109.5" y="13">Suspended</text></g></svg>
+<svg xmlns="http://www.w3.org/2000/svg" width="147" height="20">
+  <linearGradient id="smooth" x2="0" y2="100%">
+    <stop offset="0"  stop-color="#fff" stop-opacity=".7"/>
+    <stop offset=".1" stop-color="#aaa" stop-opacity=".1"/>
+    <stop offset=".9" stop-color="#000" stop-opacity=".3"/>
+    <stop offset="1"  stop-color="#000" stop-opacity=".5"/>
+  </linearGradient>
+
+  <mask id="round">
+    <rect width="147" height="20" rx="3" fill="#fff"/>
+  </mask>
+
+  <g mask="url(#round)">
+    <rect width="147" height="20" fill="#555"/>
+    <rect x="74" width="73" height="20" fill="#fe7d37"/>
+    <rect width="147" height="20" fill="url(#smooth)"/>
+  </g>
+
+  <g fill="#fff" text-anchor="middle" font-family="DejaVu Sans,Verdana,Geneva,sans-serif" font-size="11">
+    <text x="38" y="15" fill="#010101" fill-opacity=".3">repo status</text>
+    <text x="38" y="14">repo status</text>
+    <text x="109.5" y="15" fill="#010101" fill-opacity=".3">Suspended</text>
+    <text x="109.5" y="14">Suspended</text>
+  </g>
+</svg>

--- a/badges/0.1.0/unsupported-flat.svg
+++ b/badges/0.1.0/unsupported-flat.svg
@@ -1,0 +1,23 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="156" height="20">
+  <linearGradient id="smooth" x2="0" y2="100%">
+    <stop offset="0" stop-color="#bbb" stop-opacity=".1"/>
+    <stop offset="1" stop-opacity=".1"/>
+  </linearGradient>
+
+  <mask id="round">
+    <rect width="156" height="20" rx="3" fill="#fff"/>
+  </mask>
+
+  <g mask="url(#round)">
+    <rect width="156" height="20" fill="#555"/>
+    <rect x="74" width="82" height="20" fill="#9f9f9f"/>
+    <rect width="156" height="20" fill="url(#smooth)"/>
+  </g>
+
+  <g fill="#fff" text-anchor="middle" font-family="DejaVu Sans,Verdana,Geneva,sans-serif" font-size="11">
+    <text x="38" y="15" fill="#010101" fill-opacity=".3">repo status</text>
+    <text x="38" y="14">repo status</text>
+    <text x="114" y="15" fill="#010101" fill-opacity=".3">Unsupported</text>
+    <text x="114" y="14">Unsupported</text>
+  </g>
+</svg>

--- a/badges/0.1.0/unsupported.svg
+++ b/badges/0.1.0/unsupported.svg
@@ -1,1 +1,25 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="156" height="18"><linearGradient id="a" x2="0" y2="100%"><stop offset="0" stop-color="#fff" stop-opacity=".7"/><stop offset=".1" stop-color="#aaa" stop-opacity=".1"/><stop offset=".9" stop-opacity=".3"/><stop offset="1" stop-opacity=".5"/></linearGradient><rect rx="4" width="156" height="18" fill="#555"/><rect rx="4" x="74" width="82" height="18" fill="#9f9f9f"/><path fill="#9f9f9f" d="M74 0h4v18h-4z"/><rect rx="4" width="156" height="18" fill="url(#a)"/><g fill="#fff" text-anchor="middle" font-family="DejaVu Sans,Verdana,Geneva,sans-serif" font-size="11"><text x="38" y="14" fill="#010101" fill-opacity=".3">repo status</text><text x="38" y="13">repo status</text><text x="114" y="14" fill="#010101" fill-opacity=".3">Unsupported</text><text x="114" y="13">Unsupported</text></g></svg>
+<svg xmlns="http://www.w3.org/2000/svg" width="156" height="20">
+  <linearGradient id="smooth" x2="0" y2="100%">
+    <stop offset="0"  stop-color="#fff" stop-opacity=".7"/>
+    <stop offset=".1" stop-color="#aaa" stop-opacity=".1"/>
+    <stop offset=".9" stop-color="#000" stop-opacity=".3"/>
+    <stop offset="1"  stop-color="#000" stop-opacity=".5"/>
+  </linearGradient>
+
+  <mask id="round">
+    <rect width="156" height="20" rx="3" fill="#fff"/>
+  </mask>
+
+  <g mask="url(#round)">
+    <rect width="156" height="20" fill="#555"/>
+    <rect x="74" width="82" height="20" fill="#9f9f9f"/>
+    <rect width="156" height="20" fill="url(#smooth)"/>
+  </g>
+
+  <g fill="#fff" text-anchor="middle" font-family="DejaVu Sans,Verdana,Geneva,sans-serif" font-size="11">
+    <text x="38" y="15" fill="#010101" fill-opacity=".3">repo status</text>
+    <text x="38" y="14">repo status</text>
+    <text x="114" y="15" fill="#010101" fill-opacity=".3">Unsupported</text>
+    <text x="114" y="14">Unsupported</text>
+  </g>
+</svg>

--- a/badges/0.1.0/wip-flat.svg
+++ b/badges/0.1.0/wip-flat.svg
@@ -1,0 +1,23 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="107" height="20">
+  <linearGradient id="smooth" x2="0" y2="100%">
+    <stop offset="0" stop-color="#bbb" stop-opacity=".1"/>
+    <stop offset="1" stop-opacity=".1"/>
+  </linearGradient>
+
+  <mask id="round">
+    <rect width="107" height="20" rx="3" fill="#fff"/>
+  </mask>
+
+  <g mask="url(#round)">
+    <rect width="107" height="20" fill="#555"/>
+    <rect x="74" width="33" height="20" fill="#dfb317"/>
+    <rect width="107" height="20" fill="url(#smooth)"/>
+  </g>
+
+  <g fill="#fff" text-anchor="middle" font-family="DejaVu Sans,Verdana,Geneva,sans-serif" font-size="11">
+    <text x="38" y="15" fill="#010101" fill-opacity=".3">repo status</text>
+    <text x="38" y="14">repo status</text>
+    <text x="89.5" y="15" fill="#010101" fill-opacity=".3">WIP</text>
+    <text x="89.5" y="14">WIP</text>
+  </g>
+</svg>

--- a/badges/0.1.0/wip.svg
+++ b/badges/0.1.0/wip.svg
@@ -1,1 +1,25 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="107" height="18"><linearGradient id="a" x2="0" y2="100%"><stop offset="0" stop-color="#fff" stop-opacity=".7"/><stop offset=".1" stop-color="#aaa" stop-opacity=".1"/><stop offset=".9" stop-opacity=".3"/><stop offset="1" stop-opacity=".5"/></linearGradient><rect rx="4" width="107" height="18" fill="#555"/><rect rx="4" x="74" width="33" height="18" fill="#dfb317"/><path fill="#dfb317" d="M74 0h4v18h-4z"/><rect rx="4" width="107" height="18" fill="url(#a)"/><g fill="#fff" text-anchor="middle" font-family="DejaVu Sans,Verdana,Geneva,sans-serif" font-size="11"><text x="38" y="14" fill="#010101" fill-opacity=".3">repo status</text><text x="38" y="13">repo status</text><text x="89.5" y="14" fill="#010101" fill-opacity=".3">WIP</text><text x="89.5" y="13">WIP</text></g></svg>
+<svg xmlns="http://www.w3.org/2000/svg" width="107" height="20">
+  <linearGradient id="smooth" x2="0" y2="100%">
+    <stop offset="0"  stop-color="#fff" stop-opacity=".7"/>
+    <stop offset=".1" stop-color="#aaa" stop-opacity=".1"/>
+    <stop offset=".9" stop-color="#000" stop-opacity=".3"/>
+    <stop offset="1"  stop-color="#000" stop-opacity=".5"/>
+  </linearGradient>
+
+  <mask id="round">
+    <rect width="107" height="20" rx="3" fill="#fff"/>
+  </mask>
+
+  <g mask="url(#round)">
+    <rect width="107" height="20" fill="#555"/>
+    <rect x="74" width="33" height="20" fill="#dfb317"/>
+    <rect width="107" height="20" fill="url(#smooth)"/>
+  </g>
+
+  <g fill="#fff" text-anchor="middle" font-family="DejaVu Sans,Verdana,Geneva,sans-serif" font-size="11">
+    <text x="38" y="15" fill="#010101" fill-opacity=".3">repo status</text>
+    <text x="38" y="14">repo status</text>
+    <text x="89.5" y="15" fill="#010101" fill-opacity=".3">WIP</text>
+    <text x="89.5" y="14">WIP</text>
+  </g>
+</svg>


### PR DESCRIPTION
[shields.io](https://github.com/badges/shields) seems to be the standard format for shields. This pull request modifies the master branch shields to follow that template, preserving color and horizontal size of the shields. Basically this just changes the height to match shields.io (see #2) and uses the same gradient pattern. It also adds "flat" versions of the shields (again, to match options available from shields.io). I'll send a separate pull request for the gh-pages branch.