### PR TITLE
Convert hyphen to en dash in badge title text

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 repostatus.org
 ==============
 
-[![Project Status: Active - The project has reached a stable, usable state and is being actively developed.](http://www.repostatus.org/badges/latest/active.svg)](http://www.repostatus.org/#active)
+[![Project Status: Active – The project has reached a stable, usable state and is being actively developed.](http://www.repostatus.org/badges/latest/active.svg)](http://www.repostatus.org/#active)
 
 A standard to easily communicate to humans and machines the development/support and usability status of software repositories/projects.
 

--- a/fabfile.py
+++ b/fabfile.py
@@ -1,5 +1,5 @@
 """
-Repostatus.org fabfile - this is used to build badges and push to GitHub Pages.
+Repostatus.org fabfile – this is used to build badges and push to GitHub Pages.
 
 Requires Python (only tested with 2.7), Fabric and ghp-import.
 
@@ -61,7 +61,7 @@ def _download_media(url, fname):
 
 def _make_badge_markup(badge_name, description, url, savedir):
     """ generate example markup for a badge, write to disk under savedir """
-    alt = "Project Status: {statuscap} - {desc}".format(desc=description, statuscap=badge_name.capitalize())
+    alt = "Project Status: {statuscap} – {desc}".format(desc=description, statuscap=badge_name.capitalize())
     target = "http://www.repostatus.org/#{status}".format(status=badge_name)
     with open(os.path.join(savedir, '{n}_md.txt'.format(n=badge_name)), 'w') as fh:
         fh.write("[![{alt}]({url})]({target})\n".format(target=target,

--- a/gh_pages/fabfile.py
+++ b/gh_pages/fabfile.py
@@ -94,7 +94,7 @@ def _download_media(url, fname):
 
 def _make_badge_markup(badge_name, description, url, savedir):
     """ generate example markup for a badge, write to disk under savedir """
-    alt = "Project Status: {statuscap} - {desc}".format(desc=description, statuscap=badge_name.capitalize())
+    alt = "Project Status: {statuscap} – {desc}".format(desc=description, statuscap=badge_name.capitalize())
     target = "http://www.repostatus.org/#{status}".format(status=badge_name)
     with open(os.path.join(savedir, '{n}_md.txt'.format(n=badge_name)), 'w') as fh:
         fh.write("[![{alt}]({url})]({target})\n".format(target=target,

--- a/gh_pages/history.md
+++ b/gh_pages/history.md
@@ -6,8 +6,8 @@ layout: minimal
 
 I have about 50 repositories on GitHub, in varying states of completion and support. Some of them are totally abandoned, some are active (with users and everything!) and some
 are just repositories holding a ``README.md`` describing some idea I had. I was about to embark on a new project, and realized I needed to get a handle on what I currently have
-first. After some thought, I realized that an awful lot of people are in the same position. And even more so, I can't count the number of times I've dug through a repository -
-and even emailed the author - to try and figure out if it was still active or not.
+first. After some thought, I realized that an awful lot of people are in the same position. And even more so, I can't count the number of times I've dug through a repository –
+and even emailed the author – to try and figure out if it was still active or not.
 
 So, I came up with this idea. I had to stop myself before I over-engineered it too much with a formal specification and versioned API and everything.
 

--- a/gh_pages/index.md
+++ b/gh_pages/index.md
@@ -10,13 +10,13 @@ This is accomplished by including a simple badge or URL in your project's README
 
 #### Project Statuses
 
-* <a name="concept"></a>__Concept__ - Minimal or no implementation has been done yet.
-* <a name="wip"></a>__WIP__ - Initial development is in progress, but there has not yet been a stable, usable release suitable for the public.
-* <a name="suspended"></a>__Suspended__ - Initial development has started, but there has not yet been a stable, usable release; work has been stopped for the time being but the author(s) intend on resuming work.
-* <a name="abandoned"></a>__Abandoned__ - Initial development has started, but there has not yet been a stable, usable release; the project has been abandoned and the author(s) do not intend on continuing development.
-* <a name="active"></a>__Active__ - The project has reached a stable, usable state and is being actively developed.
-* <a name="inactive"></a>__Inactive__ - The project has reached a stable, usable state but is no longer being actively developed; support/maintenance will be provided as time allows.
-* <a name="unsupported"></a>__Unsupported__ - The project has reached a stable, usable state but the author(s) have ceased all work on it. A new maintainer may be desired.
+* <a name="concept"></a>__Concept__ – Minimal or no implementation has been done yet.
+* <a name="wip"></a>__WIP__ – Initial development is in progress, but there has not yet been a stable, usable release suitable for the public.
+* <a name="suspended"></a>__Suspended__ – Initial development has started, but there has not yet been a stable, usable release; work has been stopped for the time being but the author(s) intend on resuming work.
+* <a name="abandoned"></a>__Abandoned__ – Initial development has started, but there has not yet been a stable, usable release; the project has been abandoned and the author(s) do not intend on continuing development.
+* <a name="active"></a>__Active__ – The project has reached a stable, usable state and is being actively developed.
+* <a name="inactive"></a>__Inactive__ – The project has reached a stable, usable state but is no longer being actively developed; support/maintenance will be provided as time allows.
+* <a name="unsupported"></a>__Unsupported__ – The project has reached a stable, usable state but the author(s) have ceased all work on it. A new maintainer may be desired.
 
 These status descriptions and the URLs to the corresponding icons are also available in a [JSON file](/badges/latest/badges.json).
 
@@ -24,7 +24,7 @@ These status descriptions and the URLs to the corresponding icons are also avail
 
 When using the recommended method (a badge embedded in your project's README file), it's as concise as this one image:
 
-[![Project Status: Active - The project has reached a stable, usable state and is being actively developed.](http://www.repostatus.org/badges/latest/active.svg)](http://www.repostatus.org/#active)
+[![Project Status: Active – The project has reached a stable, usable state and is being actively developed.](http://www.repostatus.org/badges/latest/active.svg)](http://www.repostatus.org/#active)
 
 This incorporates three components:
 
@@ -38,13 +38,13 @@ Setting up your project to use RepoStatus.org is as simple as adding the appropr
 
 Below are the various status icons, along with paste-able markup to add them in a variety of markup languages. Feel free to alter the alt-text (after the first ``-``) to suit your needs.
 
-* __Concept__ [![Project Status: Concept - Minimal or no implementation has been done yet.](http://www.repostatus.org/badges/latest/concept.svg)](http://www.repostatus.org/#concept) [markdown](javascript:showsample('concept','md')) [ReST](javascript:showsample('concept','rst')) [HTML](javascript:showsample('concept','html'))
-* __WIP__ [![Project Status: Wip - Initial development is in progress, but there has not yet been a stable, usable release suitable for the public.](http://www.repostatus.org/badges/latest/wip.svg)](http://www.repostatus.org/#wip) [markdown](javascript:showsample('wip','md')) [ReST](javascript:showsample('wip','rst')) [HTML](javascript:showsample('wip','html'))
-* __Suspended__ [![Project Status: Suspended - Initial development has started, but there has not yet been a stable, usable release; work has been stopped for the time being but the author(s) intend on resuming work.](http://www.repostatus.org/badges/latest/suspended.svg)](http://www.repostatus.org/#suspended) [markdown](javascript:showsample('suspended','md')) [ReST](javascript:showsample('suspended','rst')) [HTML](javascript:showsample('suspended','html'))
-* __Abandoned__ [![Project Status: Abandoned - Initial development has started, but there has not yet been a stable, usable release; the project has been abandoned and the author(s) do not intend on continuing development.](http://www.repostatus.org/badges/latest/abandoned.svg)](http://www.repostatus.org/#abandoned) [markdown](javascript:showsample('abandoned','md')) [ReST](javascript:showsample('abandoned','rst')) [HTML](javascript:showsample('abandoned','html'))
-* __Active__ [![Project Status: Active - The project has reached a stable, usable state and is being actively developed.](http://www.repostatus.org/badges/latest/active.svg)](http://www.repostatus.org/#active) [markdown](javascript:showsample('active','md')) [ReST](javascript:showsample('active','rst')) [HTML](javascript:showsample('active','html'))
-* __Inactive__ [![Project Status: Inactive - The project has reached a stable, usable state but is no longer being actively developed; support/maintenance will be provided as time allows.](http://www.repostatus.org/badges/latest/inactive.svg)](http://www.repostatus.org/#inactive) [markdown](javascript:showsample('inactive','md')) [ReST](javascript:showsample('inactive','rst')) [HTML](javascript:showsample('inactive','html'))
-* __Unsupported__ [![Project Status: Unsupported - The project has reached a stable, usable state but the author(s) have ceased all work on it. A new maintainer may be desired.](http://www.repostatus.org/badges/latest/unsupported.svg)](http://www.repostatus.org/#unsupported) [markdown](javascript:showsample('unsupported','md')) [ReST](javascript:showsample('unsupported','rst')) [HTML](javascript:showsample('unsupported','html'))
+* __Concept__ [![Project Status: Concept – Minimal or no implementation has been done yet.](http://www.repostatus.org/badges/latest/concept.svg)](http://www.repostatus.org/#concept) [markdown](javascript:showsample('concept','md')) [ReST](javascript:showsample('concept','rst')) [HTML](javascript:showsample('concept','html'))
+* __WIP__ [![Project Status: Wip – Initial development is in progress, but there has not yet been a stable, usable release suitable for the public.](http://www.repostatus.org/badges/latest/wip.svg)](http://www.repostatus.org/#wip) [markdown](javascript:showsample('wip','md')) [ReST](javascript:showsample('wip','rst')) [HTML](javascript:showsample('wip','html'))
+* __Suspended__ [![Project Status: Suspended – Initial development has started, but there has not yet been a stable, usable release; work has been stopped for the time being but the author(s) intend on resuming work.](http://www.repostatus.org/badges/latest/suspended.svg)](http://www.repostatus.org/#suspended) [markdown](javascript:showsample('suspended','md')) [ReST](javascript:showsample('suspended','rst')) [HTML](javascript:showsample('suspended','html'))
+* __Abandoned__ [![Project Status: Abandoned – Initial development has started, but there has not yet been a stable, usable release; the project has been abandoned and the author(s) do not intend on continuing development.](http://www.repostatus.org/badges/latest/abandoned.svg)](http://www.repostatus.org/#abandoned) [markdown](javascript:showsample('abandoned','md')) [ReST](javascript:showsample('abandoned','rst')) [HTML](javascript:showsample('abandoned','html'))
+* __Active__ [![Project Status: Active – The project has reached a stable, usable state and is being actively developed.](http://www.repostatus.org/badges/latest/active.svg)](http://www.repostatus.org/#active) [markdown](javascript:showsample('active','md')) [ReST](javascript:showsample('active','rst')) [HTML](javascript:showsample('active','html'))
+* __Inactive__ [![Project Status: Inactive – The project has reached a stable, usable state but is no longer being actively developed; support/maintenance will be provided as time allows.](http://www.repostatus.org/badges/latest/inactive.svg)](http://www.repostatus.org/#inactive) [markdown](javascript:showsample('inactive','md')) [ReST](javascript:showsample('inactive','rst')) [HTML](javascript:showsample('inactive','html'))
+* __Unsupported__ [![Project Status: Unsupported – The project has reached a stable, usable state but the author(s) have ceased all work on it. A new maintainer may be desired.](http://www.repostatus.org/badges/latest/unsupported.svg)](http://www.repostatus.org/#unsupported) [markdown](javascript:showsample('unsupported','md')) [ReST](javascript:showsample('unsupported','rst')) [HTML](javascript:showsample('unsupported','html'))
 
 <div id="samplewrapper" style="display: none;"><h5 id="sampletitle"></h5><div id="samplecode"></div></div>
 


### PR DESCRIPTION
An en dash ‘–’ (or an em dash ‘—’) is more typographically correct than a hyphen ‘-’ when used to set off another phrase. It will make the text a tiny bit easier to read.

Here’s an example of the change. Before:

> Project Status: Concept - Minimal or no implementation has been done yet.

After:

> Project Status: Concept – Minimal or no implementation has been done yet.

You can make this update along with the “WIP” update, so you don’t have to generate the badges twice.

I also converted the hyphens in some other text: the explanations of the badges in `gh_pages/index.md`, and the beginning of `gh_pages/history.md`.

This commit does not include generating new folders in `badges/` and `gh_pages/badges/` by running the `fabfile`. It does, however, update the following files with the markup that would be generated, so you don’t have to remember to update them yourself:

- the badge at the top of `README.md`
- the What It Looks Like section of `gh_pages/index.md`
- `gh_pages/fabfile.py`