### PR TITLE
Added a formal ontology based on SKOS

### DIFF
--- a/badges/latest/ontology.jsonld
+++ b/badges/latest/ontology.jsonld
@@ -1,0 +1,91 @@
+{
+    "@context": {
+        "skos": "http://www.w3.org/2004/02/skos/core#",
+        "og": "http://ogp.me/ns#",
+        "dct": "http://purl.org/dc/terms/",
+        "Concept": { "@id": "skos:Concept" },
+        "ConceptScheme": { "@id": "skos:Concept" },
+        "title": { "@id": "dct:title" },
+        "description": { "@id": "dct:description" },
+        "creator": { "@id": "dct:creator" },
+        "prefLabel": { "@id": "skos:prefLabel" },
+        "altLabel": { "@id": "skos:altLabel" },
+        "definition": { "@id": "skos:definition" },
+        "inScheme": { "@id": "skos:inScheme" },
+        "image": { "@id": "og:image" }
+    },
+    "@graph": [
+        {
+            "@id": "https://www.repostatus.org",
+            "@type": "ConceptScheme",
+            "title": "repostatus.org",
+            "description": "A standard to easily communicate to humans and machines the development/support and usability status of software repositories/projects.",
+            "creator": "Jason Antman"
+        },
+        {
+            "@id": "https://www.repostatus.org/#abandoned",
+            "@type": "Concept",
+            "prefLabel": "Abandoned",
+            "definition": "Initial development has started, but there has not yet been a stable, usable release; the project has been abandoned and the author(s) do not intend on continuing development.",
+            "inScheme": "https://www.repostatus.org",
+            "image": "https://www.repostatus.org/badges/latest/abandoned.svg"
+        },
+        {
+            "@id": "https://www.repostatus.org/#active",
+            "@type": "Concept",
+            "prefLabel": "Active",
+            "definition": "The project has reached a stable, usable state and is being actively developed.",
+            "inScheme": "https://www.repostatus.org",
+            "image": "https://www.repostatus.org/badges/latest/active.svg"
+        },
+        {
+            "@id": "https://www.repostatus.org/#concept",
+            "@type": "Concept",
+            "prefLabel": "Concept",
+            "definition": "Minimal or no implementation has been done yet, or the repository is only intended to be a limited example, demo, or proof-of-concept.",
+            "inScheme": "https://www.repostatus.org",
+            "image": "https://www.repostatus.org/badges/latest/concept.svg"
+        },
+        {
+            "@id": "https://www.repostatus.org/#inactive",
+            "@type": "Concept",
+            "prefLabel": "Inactive",
+            "definition": "The project has reached a stable, usable state but is no longer being actively developed; support/maintenance will be provided as time allows.",
+            "inScheme": "https://www.repostatus.org",
+            "image": "https://www.repostatus.org/badges/latest/inactive.svg"
+        },
+        {
+            "@id": "https://www.repostatus.org/#moved",
+            "@type": "Concept",
+            "prefLabel": "Moved",
+            "definition": "The project has been moved to a new location, and the version at that location should be considered authoritative.",
+            "inScheme": "https://www.repostatus.org",
+            "image": "https://www.repostatus.org/badges/latest/moved.svg"
+        },
+        {
+            "@id": "https://www.repostatus.org/#suspended",
+            "@type": "Concept",
+            "prefLabel": "Suspended",
+            "definition": "Initial development has started, but there has not yet been a stable, usable release; work has been stopped for the time being but the author(s) intend on resuming work.",
+            "inScheme": "https://www.repostatus.org",
+            "image": "https://www.repostatus.org/badges/latest/suspended.svg"
+        },
+        {
+            "@id": "https://www.repostatus.org/#unsupported",
+            "@type": "Concept",
+            "prefLabel": "Unsupported",
+            "definition": "The project has reached a stable, usable state but the author(s) have ceased all work on it. A new maintainer may be desired.",
+            "inScheme": "https://www.repostatus.org",
+            "image": "https://www.repostatus.org/badges/latest/unsupported.svg"
+        },
+        {
+            "@id": "https://www.repostatus.org/#wip",
+            "@type": "Concept",
+            "prefLabel": "WIP",
+            "altLabel": "Work in Progress",
+            "definition": "Initial development is in progress, but there has not yet been a stable, usable release suitable for the public.",
+            "inScheme": "https://www.repostatus.org",
+            "image": "https://www.repostatus.org/badges/latest/wip.svg"
+        }
+  ]
+}

--- a/gh_pages/index.md
+++ b/gh_pages/index.md
@@ -19,7 +19,7 @@ This is accomplished by including a simple badge or URL in your project's README
 * <a name="unsupported"></a>__Unsupported__ – The project has reached a stable, usable state but the author(s) have ceased all work on it. A new maintainer may be desired.
 * <a name="moved"></a>__Moved__ - The project has been moved to a new location, and the version at that location should be considered authoritative. This status should be accompanied by a new URL.
 
-These status descriptions and the URLs to the corresponding icons are also available in a [JSON file](/badges/latest/badges.json).
+These status descriptions and the URLs to the corresponding icons are also available in a [JSON file](/badges/latest/badges.json) or in a more formal ontology using SKOS, defined in a [JSON-LD file](/badges/latest/ontology.jsonld).
 
 ### What It Looks Like
 
@@ -57,6 +57,8 @@ If for some reason you don't want people to see the repostatus.org status identi
 ### Specification
 
 I really wanted to write a full specification for this, complete with versioned URLs and JSON metadata describing the different statuses. If anyone else in the world wants to use this stuff, maybe I'll do that. In the mean time, here's the current version of the "specification".
+
+For use of the repostatus.org vocabulary in a linked open data context, consult the [JSON-LD file](/badges/latest/ontology.jsonld).
 
 #### Identifier Strings
 

--- a/gh_pages/index.md
+++ b/gh_pages/index.md
@@ -19,7 +19,7 @@ This is accomplished by including a simple badge or URL in your project's README
 * <a name="unsupported"></a>__Unsupported__ – The project has reached a stable, usable state but the author(s) have ceased all work on it. A new maintainer may be desired.
 * <a name="moved"></a>__Moved__ - The project has been moved to a new location, and the version at that location should be considered authoritative. This status should be accompanied by a new URL.
 
-These status descriptions and the URLs to the corresponding icons are also available in a [JSON file](/badges/latest/badges.json) or in a more formal ontology using SKOS, defined in a [JSON-LD file](/badges/latest/ontology.jsonld).
+These status descriptions and the URLs to the corresponding icons are also available in a [JSON file](/badges/latest/badges.json) or in a more formal ontology using [SKOS](https://www.w3.org/TR/skos-reference/), defined in a [JSON-LD file](/badges/latest/ontology.jsonld).
 
 ### What It Looks Like
 


### PR DESCRIPTION
In order to allow repostatus.org to be used in the linked open data
world, it would help to have the concepts expressed in a way that allows
linking with the wider semantic web. This is my attempt at doing so in
an as unobtrusive way as possible. I opted for JSON-LD as the
serialisation format, which is easily parsable and even retains some
value even if you were ignore the context that maps it to an RDF model.

I defined the all of the concepts defined in repostatus as SKOS Concepts
(https://www.w3.org/TR/skos-reference/), as that is a common and
relatively simple way to organize knowledge. The concepts together form
a ConceptScheme. I added opengraph vocabulary to link to the badge image
(as SKOS has no vocabulary for that).

Ideally this ontology.jsonld file should be served on repostatus.org if
the client sends an HTTP request with header `Accept: application/json+ld` (content
negotation).